### PR TITLE
Remove clearOptins.js reference

### DIFF
--- a/cartridges/int_ordergroove/cartridge/templates/default/checkout/confirmation/confirmation.isml
+++ b/cartridges/int_ordergroove/cartridge/templates/default/checkout/confirmation/confirmation.isml
@@ -3,7 +3,6 @@
         var assets = require('*/cartridge/scripts/assets.js');
         assets.addCss('/css/checkout/checkout.css');
         assets.addJs('/js/checkoutRegistration.js');
-        assets.addJs('/js/clearOptins.js');
     </isscript>
 
     <isif condition="${pdict.reportingURLs && pdict.reportingURLs.length}">


### PR DESCRIPTION
The code was moved to be [executed inline here](https://github.com/ordergroove/salesforce-cartridge/blob/master/cartridges/int_ordergroove/cartridge/templates/default/checkout/confirmation/confirmationCopy.isml#L7) but the reference was kept in this file. This file no longer exists so we should not be attempting to include it here.